### PR TITLE
running ./_helpers/build-infra fails on components backend.tf.example

### DIFF
--- a/terraform/components/forseti/backend.tf.example
+++ b/terraform/components/forseti/backend.tf.example
@@ -17,7 +17,7 @@ terraform {
   required_version = "~> 0.11.13"
 
   backend "gcs" {
-    bucket = "BUCKET_PREFIX-terraform-admin"
+    bucket = "TF_ADMIN_BUCKET"
     prefix = "terraform/state/components/forseti"
   }
 }

--- a/terraform/components/in-scope/backend.tf.example
+++ b/terraform/components/in-scope/backend.tf.example
@@ -17,7 +17,7 @@ terraform {
   required_version = "~> 0.11.13"
 
   backend "gcs" {
-    bucket = "BUCKET_PREFIX-terraform-admin"
+    bucket = "TF_ADMIN_BUCKET"
     prefix = "terraform/state/components/in-scope/infrastructure"
   }
 }

--- a/terraform/components/logging/backend.tf.example
+++ b/terraform/components/logging/backend.tf.example
@@ -17,7 +17,7 @@ terraform {
   required_version = "~> 0.11.13"
 
   backend "gcs" {
-    bucket = "BUCKET_PREFIX-terraform-admin"
+    bucket = "TF_ADMIN_BUCKET"
     prefix = "terraform/state/components/logging"
   }
 }

--- a/terraform/components/out-of-scope/backend.tf.example
+++ b/terraform/components/out-of-scope/backend.tf.example
@@ -17,7 +17,7 @@ terraform {
   required_version = "~> 0.11.13"
 
   backend "gcs" {
-    bucket = "BUCKET_PREFIX-terraform-admin"
+    bucket = "TF_ADMIN_BUCKET"
     prefix = "terraform/state/components/out-of-scope/infrastructure"
   }
 }


### PR DESCRIPTION

running ./_helpers/build-infra fails on components backend.tf.example 
Failure is happening since bucket name placeholder is not overridden correctly.
The following commit modifies the components/*/backend.tf.example to be on the same convention as projects/*/backend.tf.example