### PR TITLE
Alpha calls, DLP curl, and fix helm chart namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,8 @@ terraform.out
 *.pyc
 *.profraw
 *tfstate*
+*.tmp
 workstation.env
+hipsterservice.crt
+hipsterservice.csr
+hipsterservice.key

--- a/README.md
+++ b/README.md
@@ -361,39 +361,17 @@ utilizing it to mask sensitive cardholder data from StackDriver logs. See
 
 **Documentation**: [Creating Cloud DLP de-identification templates](https://cloud.google.com/dlp/docs/creating-templates-deid)
 
-A deidentification template needs to be created to pass to the DLP API filter
-configuration. There are multiple methods for creating the template. The method
-used here is the GCP documentation's API Explorer.
+A deidentification template needs to be created to pass to the DLP API filter configuration.  To create the template, run the following `curl` command:
 
-1. In a browser, navigate to https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates/create
-1. In the sidebar, in the "Request parameters" section, in the `parent` field,
-enter `projects/<YOUR_INSCOPE_PROJECT>` eg. `projects/pci-poc-in-scope`
-1. In the request field, enter these values:
-  {
-    "deidentifyTemplate": {
-       "deidentifyConfig": {
-           "infoTypeTransformations": {
-             "transformations": [
-               {
-                 "infoTypes": [
-                   {
-                     "name": "CREDIT_CARD_NUMBER"
-                   }
-                 ],
-                 "primitiveTransformation": {
-                   "replaceWithInfoTypeConfig": {}
-                 }
-               }
-             ]
-           }
-         }
-       }
-     }
-1. Use the "EXECUTE" button to trigger the API call. You'll be prompted for
-authentication if needed.
-1. A valid API call will result in a table towards the bottom with a green header
-and the string "200". Copy the value of the `name` field to save it.
-1. In the `workstation.env` file, replace `TBD` from the line `export DEIDENTIFY_TEMPLATE_NAME=TBD` with this value.
+```
+curl -H "Content-Type: application/json; charset=utf-8" -H "Authorization: Bearer $(gcloud auth print-access-token)" -XPOST -d'{ "deidentifyTemplate": { "deidentifyConfig": { "infoTypeTransformations": { "transformations": [ { "infoTypes": [ { "name": "CREDIT_CARD_NUMBER" } ], "primitiveTransformation": { "replaceWithInfoTypeConfig": {} } } ] } } } }' "https://dlp.googleapis.com/v2/projects/${TF_VAR_project_prefix}-in-scope/deidentifyTemplates"
+```
+
+In the `workstation.env` file, replace `TBD` from the line `export DEIDENTIFY_TEMPLATE_NAME=TBD` with the full contents of the returned `name` value. For example:
+
+```
+export DEIDENTIFY_TEMPLATE_NAME="projects/${TF_VAR_project_prefix}-in-scope/deidentifyTemplates/NNNNNNNNNNNNNNNNNN"
+```
 
 #### Build the Custom `fluentd-gcp` Container
 

--- a/_helpers/admin_project_setup.sh
+++ b/_helpers/admin_project_setup.sh
@@ -32,7 +32,7 @@ echo "Continuing in 10 seconds. Ctrl+C to cancel"
 sleep 10
 
 echo "=> Creating project inside the folder ${TF_VAR_folder_id}"
-gcloud alpha projects create "${TF_ADMIN_PROJECT}" \
+gcloud projects create "${TF_ADMIN_PROJECT}" \
   --folder "${TF_VAR_folder_id}"
 
 echo "=> Linking ${TF_VAR_billing_account} Billing Account to your project"
@@ -46,6 +46,7 @@ gcloud --project "${TF_ADMIN_PROJECT}" services enable cloudbilling.googleapis.c
 gcloud --project "${TF_ADMIN_PROJECT}" services enable iam.googleapis.com
 gcloud --project "${TF_ADMIN_PROJECT}" services enable admin.googleapis.com
 gcloud --project "${TF_ADMIN_PROJECT}" services enable sqladmin.googleapis.com
+gcloud --project "${TF_ADMIN_PROJECT}" services enable dlp.googleapis.com
 
 echo "=> Creating Terraform state bucket"
 gsutil mb -p "${TF_ADMIN_PROJECT}" "gs://${TF_ADMIN_BUCKET}"
@@ -54,6 +55,6 @@ gsutil versioning set on "gs://${TF_ADMIN_BUCKET}"
 echo ""
 echo "Admin resources created successfully"
 echo ""
-echo 'To continue with setting up a Terraform Service Account please run "helpers/setup_service_account.sh"'
+echo 'To continue with setting up a Terraform Service Account please run "./_helpers/setup_service_account.sh"'
 echo ""
 

--- a/_helpers/forseti_admin_permissions.sh
+++ b/_helpers/forseti_admin_permissions.sh
@@ -47,11 +47,11 @@ gcloud organizations add-iam-policy-binding "${TF_VAR_org_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/serviceusage.serviceUsageAdmin
 
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/iam.serviceAccountAdmin
 
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/cloudsql.admin
 

--- a/_helpers/setup_service_account.sh
+++ b/_helpers/setup_service_account.sh
@@ -54,49 +54,49 @@ gcloud projects add-iam-policy-binding "${TF_ADMIN_PROJECT}" \
   --role roles/storage.admin
 
 # Add Storage Admin permissions to entire Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/storage.admin
 
 # Add Container cluster admin permissions to entire Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/container.admin
 
 # Add IAM serviceAccountUser permissions to entire Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/iam.serviceAccountUser
 
 # Add Project Creator permissions to entire Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/resourcemanager.projectCreator
 
 # Add Billing Project Manager permissions to all projects in Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/billing.projectManager
 
 # Add Compute Admin permissions to all projects in Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/compute.admin
 
 # Add Shared VPC Admin permissions to all projects in Folder
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/compute.xpnAdmin
 
 echo "=> Setting up IAM roles for StackDriver Logging"
 
-gcloud alpha resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
+gcloud resource-manager folders add-iam-policy-binding "${TF_VAR_folder_id}" \
   --member "serviceAccount:terraform@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
   --role roles/logging.configWriter
 
 echo ""
 echo "Service Account set up successfully"
 echo ""
-echo 'To continue setting up permissions for Forseti please run "helpers/forseti_admin_permissions.sh"'
+echo 'To continue setting up permissions for Forseti please run "./_helpers/forseti_admin_permissions.sh"'
 echo ""
 

--- a/helm/fluentd-custom-target-project/templates/fluentd-configmap.yaml
+++ b/helm/fluentd-custom-target-project/templates/fluentd-configmap.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fluentd-config
-namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   containers.input.conf: |-
     # This configuration file for Fluentd is used

--- a/helm/fluentd-custom-target-project/templates/fluentd-daemonset.yaml
+++ b/helm/fluentd-custom-target-project/templates/fluentd-daemonset.yaml
@@ -14,12 +14,12 @@
 
 apiVersion: extensions/v1beta1
 kind: DaemonSet
-namespace: {{ .Release.Namespace }}
 metadata:
   labels:
     k8s-app: fluentd-gcp
     version: v3.2.0
   name: fluentd-gcp-v3.2.0
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/fluentd-filter-dlp/templates/fluentd-configmap.yaml
+++ b/helm/fluentd-filter-dlp/templates/fluentd-configmap.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fluentd-config
-namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   containers.input.conf: |-
     # This configuration file for Fluentd is used

--- a/helm/fluentd-filter-dlp/templates/fluentd-daemonset.yaml
+++ b/helm/fluentd-filter-dlp/templates/fluentd-daemonset.yaml
@@ -14,12 +14,12 @@
 
 apiVersion: extensions/v1beta1
 kind: DaemonSet
-namespace: {{ .Release.Namespace }}
 metadata:
   labels:
     k8s-app: fluentd-gcp
     version: v3.2.0
   name: fluentd-gcp-v3.2.0
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This PR:
- Removes `gcloud alpha` calls for project creation
- Replaces the DLP API explorer method with a `curl` based approach
- Adds `hipsterservice.*` and `*.tmp` to `.gitignore`
- Resolves the `namespace` spec errors in the `fluentd` charts

Note: I had to enable the `dlp` API on the `-tf-admin` project for the `curl` call to be able to use the `terraform@` service account's credentials and for that `curl` to succeed.