### PR TITLE
Migrate to Terraform v0.12 and newer module versions

### DIFF
--- a/terraform/components/forseti/backend.tf.example
+++ b/terraform/components/forseti/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
 
   backend "gcs" {
     bucket = "TF_ADMIN_BUCKET"

--- a/terraform/components/in-scope/backend.tf.example
+++ b/terraform/components/in-scope/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
 
   backend "gcs" {
     bucket = "TF_ADMIN_BUCKET"

--- a/terraform/components/in-scope/ip.tf
+++ b/terraform/components/in-scope/ip.tf
@@ -15,7 +15,7 @@
  */
 resource "google_compute_global_address" "frontend-ext-ip" {
   name         = "frontend-ext-ip"
-  project      = "${data.terraform_remote_state.project_in_scope.project_id}"
+  project      = data.terraform_remote_state.project_in_scope.outputs.project_id
   description  = "The external IP address for the frontend of the Demo site."
   address_type = "EXTERNAL"
 }

--- a/terraform/components/logging/backend.tf.example
+++ b/terraform/components/logging/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
 
   backend "gcs" {
     bucket = "TF_ADMIN_BUCKET"

--- a/terraform/components/out-of-scope/backend.tf.example
+++ b/terraform/components/out-of-scope/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
 
   backend "gcs" {
     bucket = "TF_ADMIN_BUCKET"

--- a/terraform/components/out-of-scope/cluster.tf
+++ b/terraform/components/out-of-scope/cluster.tf
@@ -17,8 +17,8 @@
 data "terraform_remote_state" "project_out_of_scope" {
   backend = "gcs"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
+  config = {
+    bucket = var.remote_state_bucket
     prefix = "terraform/state/out-of-scope"
   }
 }
@@ -26,24 +26,25 @@ data "terraform_remote_state" "project_out_of_scope" {
 data "terraform_remote_state" "project_network" {
   backend = "gcs"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
+  config = {
+    bucket = var.remote_state_bucket
     prefix = "terraform/state/network"
   }
 }
 
 resource "google_container_cluster" "primary" {
-  name               = "${local.out_of_scope_cluster_name}"
-  min_master_version = "${local.gke_minimum_version}"
+  name               = local.out_of_scope_cluster_name
+  min_master_version = local.gke_minimum_version
   location           = "us-central1-a"
   node_locations     = ["us-central1-b"]
-  network            = "${data.terraform_remote_state.project_network.vpc_self_link}"
-  subnetwork         = "projects/${data.terraform_remote_state.project_network.project_id}/regions/${var.region}/subnetworks/${local.out_of_scope_subnet_name}"
-  project            = "${data.terraform_remote_state.project_out_of_scope.project_id}"
+  network            = data.terraform_remote_state.project_network.outputs.vpc_self_link
+  subnetwork         = "projects/${data.terraform_remote_state.project_network.outputs.project_id}/regions/${var.region}/subnetworks/${local.out_of_scope_subnet_name}"
+  project            = data.terraform_remote_state.project_out_of_scope.outputs.project_id
 
   # We use a custom fluentd DaemonSet to manage logging. We do this so we can
   # configure filter rules to mask sensitive data.
-  logging_service = "none"
+  logging_service    = "none"
+  monitoring_service = "monitoring.googleapis.com"
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default
@@ -55,7 +56,7 @@ resource "google_container_cluster" "primary" {
   # Required for initial cluster setup. Avoids setting the node service
   # account to the incorrect default service account.
   node_config {
-    service_account = "${data.terraform_remote_state.project_out_of_scope.service_account_email}"
+    service_account = data.terraform_remote_state.project_out_of_scope.outputs.service_account_email
     preemptible     = true
     tags            = ["out-of-scope"]
   }
@@ -71,15 +72,15 @@ resource "google_container_cluster" "primary" {
   }
 
   ip_allocation_policy {
-    use_ip_aliases                = true
-    cluster_secondary_range_name  = "${local.out_of_scope_pod_ip_range_name}"
-    services_secondary_range_name = "${local.out_of_scope_services_ip_range_name}"
+    cluster_secondary_range_name  = local.out_of_scope_pod_ip_range_name
+    services_secondary_range_name = local.out_of_scope_services_ip_range_name
   }
 
   private_cluster_config {
     # In a private cluster, nodes do not have public IP addresses, and the master
     # is inaccessible by default.
-    enable_private_nodes = true
+    enable_private_nodes    = true
+    enable_private_endpoint = false
 
     # "Master IP range" is a private RFC 1918 reange for the master's VPC. The
     # master range must not overlap with any subnet in your cluster's VPC. The
@@ -101,8 +102,8 @@ resource "google_container_cluster" "primary" {
 
 resource "google_container_node_pool" "primary_preemptible_nodes" {
   name               = "${local.out_of_scope_cluster_name}-node-pool"
-  depends_on         = ["google_container_cluster.primary"]
-  version            = "${local.gke_minimum_version}"
+  depends_on         = [google_container_cluster.primary]
+  version            = local.gke_minimum_version
   location           = "us-central1-a"
   initial_node_count = 2
 
@@ -116,13 +117,13 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     auto_upgrade = true
   }
 
-  cluster = "${google_container_cluster.primary.name}"
-  project = "${data.terraform_remote_state.project_out_of_scope.project_id}"
+  cluster = google_container_cluster.primary.name
+  project = data.terraform_remote_state.project_out_of_scope.outputs.project_id
 
   node_config {
     preemptible     = true
     machine_type    = "n1-standard-1"
-    service_account = "${data.terraform_remote_state.project_out_of_scope.service_account_email}"
+    service_account = data.terraform_remote_state.project_out_of_scope.outputs.service_account_email
 
     tags = ["out-of-scope"]
 

--- a/terraform/projects/in-scope/backend.tf.example
+++ b/terraform/projects/in-scope/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
   backend "gcs" {
     bucket  = "TF_ADMIN_BUCKET"
     prefix  = "terraform/state/in-scope"

--- a/terraform/projects/in-scope/main.tf
+++ b/terraform/projects/in-scope/main.tf
@@ -17,24 +17,24 @@
 data "terraform_remote_state" "project_network" {
   backend = "gcs"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
+  config = {
+    bucket = var.remote_state_bucket
     prefix = "terraform/state/network"
   }
 }
 
 module "project_in_scope" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "2.1.1"
+  version = "~> 6.2.1"
 
-  name            = "${local.project_in_scope}"
-  org_id          = "${var.org_id}"
-  domain          = "${var.domain}"
-  billing_account = "${var.billing_account}"
-  folder_id       = "${local.folder_id}"
+  name            = local.project_in_scope
+  org_id          = var.org_id
+  domain          = var.domain
+  billing_account = var.billing_account
+  folder_id       = local.folder_id
 
-  shared_vpc                  = "${data.terraform_remote_state.project_network.project_id}"
-  shared_vpc_subnets          = ["${local.in_scope_subnet_self_link}"]
+  shared_vpc                  = data.terraform_remote_state.project_network.outputs.project_id
+  shared_vpc_subnets          = [local.in_scope_subnet_self_link]
   disable_services_on_destroy = false
 
   activate_apis = [
@@ -50,55 +50,55 @@ module "project_in_scope" {
 }
 
 data "google_project" "in_scope_google_project" {
-  project_id = "${module.project_in_scope.project_id}"
+  project_id = module.project_in_scope.project_id
 }
 
 # Add this project's Kubernetes Engine Service Agent
 # to the custom "Firewall Admin" role managed in the network project
 resource "google_project_iam_member" "add_firewall_admin" {
-  project = "${data.terraform_remote_state.project_network.project_id}"
-  role    = "${data.terraform_remote_state.project_network.firewall_admin_role_id_custom_formatted}"
+  project = data.terraform_remote_state.project_network.outputs.project_id
+  role    = data.terraform_remote_state.project_network.outputs.firewall_admin_role_id_custom_formatted
   member  = "serviceAccount:service-${data.google_project.in_scope_google_project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 # Add permissions to write logs to Stackdriver
 resource "google_project_iam_binding" "add_stackdriver_write_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/logging.logWriter"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 # Add permissions to Debug info to Stackdriver
 resource "google_project_iam_binding" "add_stackdriver_debugger_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/clouddebugger.agent"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 # Add permissions to add Trace data
 resource "google_project_iam_binding" "add_cloudtrace_agent_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/cloudtrace.agent"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 # Add permissions to write Metrics
 resource "google_project_iam_binding" "add_monitoring_metricwriter_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/monitoring.metricWriter"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 # Add permissions to view Cloud Storage objects
 resource "google_project_iam_binding" "add_storage_objectviewer_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/storage.objectViewer"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 # Adds the ability to redact content using Data-Loss Prevention API
 resource "google_project_iam_binding" "add_dlp_user_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/dlp.user"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
@@ -106,22 +106,22 @@ resource "google_project_iam_binding" "add_dlp_user_role" {
 # Access DLP De-identification Templates
 # See <https://cloud.google.com/dlp/docs/concepts-templates>
 resource "google_project_iam_binding" "add_dlp_deidentifyTemplatesReader_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/dlp.deidentifyTemplatesReader"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 # Send Profiler data to CloudProfiler
 resource "google_project_iam_binding" "add_cloudprofiler_agent_role" {
-  project = "${module.project_in_scope.project_id}"
+  project = module.project_in_scope.project_id
   role    = "roles/cloudprofiler.agent"
   members = ["serviceAccount:${module.project_in_scope.service_account_email}"]
 }
 
 output "project_id" {
-  value = "${module.project_in_scope.project_id}"
+  value = module.project_in_scope.project_id
 }
 
 output "service_account_email" {
-  value = "${module.project_in_scope.service_account_email}"
+  value = module.project_in_scope.service_account_email
 }

--- a/terraform/projects/management/backend.tf.example
+++ b/terraform/projects/management/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
   backend "gcs" {
     bucket  = "TF_ADMIN_BUCKET"
     prefix  = "terraform/state/management"

--- a/terraform/projects/management/main.tf
+++ b/terraform/projects/management/main.tf
@@ -17,24 +17,24 @@
 data "terraform_remote_state" "project_network" {
   backend = "gcs"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
+  config = {
+    bucket = var.remote_state_bucket
     prefix = "terraform/state/network"
   }
 }
 
 module "project_management" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "2.1.1"
+  version = "~> 6.2.1"
 
-  name   = "${local.project_management}"
-  org_id = "${var.org_id}"
+  name   = local.project_management
+  org_id = var.org_id
 
-  domain          = "${var.domain}"
-  billing_account = "${var.billing_account}"
-  folder_id       = "${local.folder_id}"
+  domain          = var.domain
+  billing_account = var.billing_account
+  folder_id       = local.folder_id
 
-  shared_vpc         = "${data.terraform_remote_state.project_network.project_id}"
+  shared_vpc         = data.terraform_remote_state.project_network.outputs.project_id
   shared_vpc_subnets = ["projects/${local.project_network}/regions/${var.region}/subnetworks/${local.mgmt_subnet_name}"]
 
   activate_apis = [
@@ -43,5 +43,5 @@ module "project_management" {
 }
 
 output project_id {
-  value = "${module.project_management.project_id}"
+  value = module.project_management.project_id
 }

--- a/terraform/projects/network/backend.tf.example
+++ b/terraform/projects/network/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
   backend "gcs" {
     bucket  = "TF_ADMIN_BUCKET"
     prefix  = "terraform/state/network"

--- a/terraform/projects/out-of-scope/backend.tf.example
+++ b/terraform/projects/out-of-scope/backend.tf.example
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.12.19"
   backend "gcs" {
     bucket  = "TF_ADMIN_BUCKET"
     prefix  = "terraform/state/out-of-scope"

--- a/terraform/projects/out-of-scope/main.tf
+++ b/terraform/projects/out-of-scope/main.tf
@@ -17,24 +17,24 @@
 data "terraform_remote_state" "project_network" {
   backend = "gcs"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
+  config = {
+    bucket = var.remote_state_bucket
     prefix = "terraform/state/network"
   }
 }
 
 module "project_out_of_scope" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "2.1.1"
+  version = "~> 6.2.1"
 
-  name            = "${local.project_out_of_scope}"
-  org_id          = "${var.org_id}"
-  domain          = "${var.domain}"
-  billing_account = "${var.billing_account}"
-  folder_id       = "${local.folder_id}"
+  name            = local.project_out_of_scope
+  org_id          = var.org_id
+  domain          = var.domain
+  billing_account = var.billing_account
+  folder_id       = local.folder_id
 
-  shared_vpc         = "${data.terraform_remote_state.project_network.project_id}"
-  shared_vpc_subnets = ["${local.out_of_scope_subnet_self_link}"]
+  shared_vpc         = data.terraform_remote_state.project_network.outputs.project_id
+  shared_vpc_subnets = [local.out_of_scope_subnet_self_link]
 
   activate_apis = [
     "compute.googleapis.com",
@@ -48,56 +48,56 @@ module "project_out_of_scope" {
 }
 
 data "google_project" "out_of_scope_google_project" {
-  project_id = "${module.project_out_of_scope.project_id}"
+  project_id = module.project_out_of_scope.project_id
 }
 
 # Add this project's Kubernetes Engine Service Agent
 # to the custom "Firewall Admin" role managed in the network project
 resource "google_project_iam_member" "add_firewall_admin" {
-  project = "${data.terraform_remote_state.project_network.project_id}"
-  role    = "${data.terraform_remote_state.project_network.firewall_admin_role_id_custom_formatted}"
+  project = data.terraform_remote_state.project_network.outputs.project_id
+  role    = data.terraform_remote_state.project_network.outputs.firewall_admin_role_id_custom_formatted
   member  = "serviceAccount:service-${data.google_project.out_of_scope_google_project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 # Add permissions to write logs to Stackdriver
 resource "google_project_iam_binding" "add_stackdriver_write_role" {
-  project = "${module.project_out_of_scope.project_id}"
+  project = module.project_out_of_scope.project_id
   role    = "roles/logging.logWriter"
   members = ["serviceAccount:${module.project_out_of_scope.service_account_email}"]
 }
 
 # Add permissions to Debug info to Stackdriver
 resource "google_project_iam_binding" "add_stackdriver_debugger_role" {
-  project = "${module.project_out_of_scope.project_id}"
+  project = module.project_out_of_scope.project_id
   role    = "roles/clouddebugger.agent"
   members = ["serviceAccount:${module.project_out_of_scope.service_account_email}"]
 }
 
 # Add permissions to add Trace data
 resource "google_project_iam_binding" "add_cloudtrace_agent_role" {
-  project = "${module.project_out_of_scope.project_id}"
+  project = module.project_out_of_scope.project_id
   role    = "roles/cloudtrace.agent"
   members = ["serviceAccount:${module.project_out_of_scope.service_account_email}"]
 }
 
 # Add permissions to write Metrics
 resource "google_project_iam_binding" "add_monitoring_metricwriter_role" {
-  project = "${module.project_out_of_scope.project_id}"
+  project = module.project_out_of_scope.project_id
   role    = "roles/monitoring.metricWriter"
   members = ["serviceAccount:${module.project_out_of_scope.service_account_email}"]
 }
 
 # Add permissions to view Cloud Storage objects
 resource "google_project_iam_binding" "add_storage_objectviewer_role" {
-  project = "${module.project_out_of_scope.project_id}"
+  project = module.project_out_of_scope.project_id
   role    = "roles/storage.objectViewer"
   members = ["serviceAccount:${module.project_out_of_scope.service_account_email}"]
 }
 
 output "project_id" {
-  value = "${module.project_out_of_scope.project_id}"
+  value = module.project_out_of_scope.project_id
 }
 
 output "service_account_email" {
-  value = "${module.project_out_of_scope.service_account_email}"
+  value = module.project_out_of_scope.service_account_email
 }

--- a/terraform/shared.tf.example
+++ b/terraform/shared.tf.example
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Provider versions set to ~> 2.12 -- the maximum version for the `logging` component.
+# TODO: Update the Providers to their latest versions as soon as the
+# `terraform-google-log-export` module supports a version >= 3.0
 provider "google" {
-  version = "~> 2.1"
-  region  = "${var.region}"
+  version = "~> 2.12"
+  region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 2.1"
-  region  = "${var.region}"
+  version = "~> 2.12"
+  region  = var.region
 }
 
 variable "billing_account" {
@@ -62,8 +65,8 @@ variable "remote_state_bucket" {
 }
 
 locals {
-  folder_id               = "${ var.folder_id != "" ? var.folder_id : "" }"
-  gke_minimum_version     = "1.12.7-gke.25"
+  folder_id               = "${var.folder_id != "" ? var.folder_id : ""}"
+  gke_minimum_version     = "1.14.8-gke.12"
   self_link_subnet_prefix = "projects/${local.project_network}/regions/${var.region}/subnetworks/"
 
   in_scope_cluster_name           = "in-scope"


### PR DESCRIPTION
Provides a much needed cleanup and migration to newer module versions, providers, and Terraform v0.12 syntax

**NOTE**: This is intended as a refactor with no functionality changes. This version should create the same functioning the demo as before.

## Upgrades and new module versions
- Upgrades syntax and configuration files to support Terraform v0.12.19
- Upgrades Project Factory module to version ~> 6.2.1
- Upgrades Network module to version ~> 2.0.1
- Upgrades Google provider versions to ~> 2.12
- Upgrades Log Export module to version 3.2.0
- Upgrades Forseti module to version ~> 5.1
- GKE Minimum version defaults to `1.14.8-gke.12`. Just like before, it can still be changed by the user by setting the local variable `gke_minimum_version`

## Misc
Most changes are to migrate the Terraform syntax from v0.11 to v0.12 and includes updates to remove string interpolation syntax (i.e. `${}` around variables), whitespace / indenting, and using the `outputs` field for the `data.terraform_remote_state` resources

## Forseti Component changes
- Removes workaround. Now, variables can be used for the `server_grpc_allow_ranges` input

## In-Scope / Out-of-Scope Components
- The field `monitoring_service` is added and set to `monitoring.googleapis.com`. In previous versions, this was the default value but now must be explicitly set.
- The field `ip_allocation_policy.use_ip_aliases` can be removed. It was previously set to `true`
- The field `private_cluster_config. enable_private_endpoint` is now a required field. It is set to `false` which was the previous default value

## Network Project
- For the `in-scope` subnet, added newly required fields to control VPC Flow Log ingest rates. These values are set to collect VPC Flow Logs at a 70% ingest rate, over 10-minute aggregates, and to collect all log metadata
